### PR TITLE
Admin can log in 119 closes #119

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,11 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   def current_user
-    @current_user ||= User.find(session[:user_id]) if session[:user_id]
+    if session[:admin]
+      @current_user ||= Admin.find(session[:user_id]) if session[:user_id]
+    else
+      @current_user ||= User.find(session[:user_id]) if session[:user_id]
+    end
   end
 
   helper_method :current_user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,14 +3,27 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:session][:email])
-    if user && user.authenticate(params[:session][:password])
-      session[:user_id] = user.id
-      flash[:success] = "Successfully logged in!"
-      redirect_to(:back)
+    if Admin.find_by(email: params[:session][:email])
+      admin = Admin.find_by(email: params[:session][:email])
+      if Admin.find_by(email: params[:session][:email]).
+          authenticate(params[:session][:password])
+        session[:user_id] = admin.id
+        session[:admin] = true
+        redirect_to admin_path
+      else
+        flash[:errors] = "Invalid Login"
+        redirect_to login_path
+      end
     else
-      flash[:errors] = "Invalid Login"
-      render :new
+      user = User.find_by(email: params[:session][:email])
+      if user && user.authenticate(params[:session][:password])
+        session[:user_id] = user.id
+        flash[:success] = "Successfully logged in!"
+        redirect_to(:back)
+      else
+        flash[:errors] = "Invalid Login"
+        render :new
+      end
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -21,9 +21,9 @@ class SessionsController < ApplicationController
   def authenticate_admin(admin)
     if Admin.find_by(email: params[:session][:email]).
         authenticate(params[:session][:password])
-        session[:user_id] = admin.id
-        session[:admin] = true
-        redirect_to admin_path
+      session[:user_id] = admin.id
+      session[:admin] = true
+      redirect_to admin_path
     else
       flash[:errors] = "Invalid Login"
       redirect_to login_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,11 +3,11 @@ class SessionsController < ApplicationController
   end
 
   def create
-   if Admin.find_by(email: params[:session][:email])
+    if Admin.find_by(email: params[:session][:email])
       authenticate_admin(Admin.find_by(email: params[:session][:email]))
-   else
+    else
       authenticate_user(User.find_by(email: params[:session][:email]))
-   end
+    end
   end
 
   def destroy

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,33 +3,41 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if Admin.find_by(email: params[:session][:email])
-      admin = Admin.find_by(email: params[:session][:email])
-      if Admin.find_by(email: params[:session][:email]).
-          authenticate(params[:session][:password])
-        session[:user_id] = admin.id
-        session[:admin] = true
-        redirect_to admin_path
-      else
-        flash[:errors] = "Invalid Login"
-        redirect_to login_path
-      end
-    else
-      user = User.find_by(email: params[:session][:email])
-      if user && user.authenticate(params[:session][:password])
-        session[:user_id] = user.id
-        flash[:success] = "Successfully logged in!"
-        redirect_to(:back)
-      else
-        flash[:errors] = "Invalid Login"
-        render :new
-      end
-    end
+   if Admin.find_by(email: params[:session][:email])
+      authenticate_admin(Admin.find_by(email: params[:session][:email]))
+   else
+      authenticate_user(User.find_by(email: params[:session][:email]))
+   end
   end
 
   def destroy
     session.clear
     flash[:success] = "Successfully logged out!"
     redirect_to(:back)
+  end
+
+  private
+
+  def authenticate_admin(admin)
+    if Admin.find_by(email: params[:session][:email]).
+        authenticate(params[:session][:password])
+        session[:user_id] = admin.id
+        session[:admin] = true
+        redirect_to admin_path
+    else
+      flash[:errors] = "Invalid Login"
+      redirect_to login_path
+    end
+  end
+
+  def authenticate_user(user)
+    if user && user.authenticate(params[:session][:password])
+      session[:user_id] = user.id
+      flash[:success] = "Successfully logged in!"
+      redirect_to(:back)
+    else
+      flash[:errors] = "Invalid Login"
+      render :new
+    end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,10 @@
 class Seed
-  attr_accessor :categories, :items, :users
+  attr_accessor :categories, :items, :users, :admins
   def initialize
     generate_categories
     generate_items
     generate_users
+    generate_admins
     add_items_to_categories
     generate_orders
     change_order_statuses
@@ -187,6 +188,10 @@ class Seed
       { full_name: "Jorge Tellez", email: "demo+jorge@jumpstartlab.com", password: "password", display_name: "novohispano" },
       { full_name: "Josh Cheek", email: "demo+josh@jumpstartlab.com", password: "password", display_name: "josh", role: 1 }
     ])
+  end
+
+  def generate_admins
+    @admins = Admin.create(full_name: "Admin", email: "admin@admin.com", password: "password")
   end
 
   def generate_orders

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -185,15 +185,17 @@ class Seed
     @users = User.create([
       { full_name: "Rachel Warbelow", email: "demo+rachel@jumpstartlab.com", password: "password" },
       { full_name: "Jeff Casimir", email: "demo+jeff@jumpstartlab.com", password: "password", display_name: "j3" },
-      { full_name: "Jorge Tellez", email: "demo+jorge@jumpstartlab.com", password: "password", display_name: "novohispano" },
-      { full_name: "Josh Cheek", email: "demo+josh@jumpstartlab.com", password: "password", display_name: "josh", role: 1 }
+      { full_name: "Jorge Tellez", email: "demo+jorge@jumpstartlab.com", password: "password", display_name: "novohispano" }
     ])
   end
 
   def generate_admins
-    @admins = Admin.create(full_name: "Admin",
-                           email:     "admin@admin.com",
-                           password:  "password")
+    Admin.create(full_name: "Admin",
+                 email:     "admin@admin.com",
+                 password:  "password")
+    Admin.create(full_name:     "Josh Cheek",
+                 email:         "demo+josh@jumpstartlab.com",
+                 display_name:  "josh")
   end
 
   def generate_orders

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -183,9 +183,17 @@ class Seed
 
   def generate_users
     @users = User.create([
-      { full_name: "Rachel Warbelow", email: "demo+rachel@jumpstartlab.com", password: "password" },
-      { full_name: "Jeff Casimir", email: "demo+jeff@jumpstartlab.com", password: "password", display_name: "j3" },
-      { full_name: "Jorge Tellez", email: "demo+jorge@jumpstartlab.com", password: "password", display_name: "novohispano" }
+      { full_name:    "Rachel Warbelow",
+        email:        "demo+rachel@jumpstartlab.com",
+        password:     "password" },
+      { full_name:    "Jeff Casimir",
+        email:        "demo+jeff@jumpstartlab.com",
+        password:     "password",
+        display_name: "j3" },
+      { full_name:    "Jorge Tellez",
+        email:        "demo+jorge@jumpstartlab.com",
+        password:     "password",
+        display_name: "novohispano" }
     ])
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -191,7 +191,9 @@ class Seed
   end
 
   def generate_admins
-    @admins = Admin.create(full_name: "Admin", email: "admin@admin.com", password: "password")
+    @admins = Admin.create(full_name: "Admin",
+                           email:     "admin@admin.com",
+                           password:  "password")
   end
 
   def generate_orders

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,9 +1,9 @@
 FactoryGirl.define do
   factory :admin do
     full_name "Yolo Ono"
-    email "nope@nope.com"
-    password "testtest"
-    display_name "This Is Your Admin"
+    email "admin@admin.com"
+    password "password"
+    display_name "Admin"
   end
 
   factory :user do

--- a/spec/integration/admin_login_spec.rb
+++ b/spec/integration/admin_login_spec.rb
@@ -9,8 +9,8 @@ describe "admin authorization", type: :feature do
 
       visit root_url
       click_link("Login")
-      fill_in "session[email]", { with: "admin@admin.com" }
-      fill_in "session[password]", { with: "password" }
+      fill_in "session[email]", with: "admin@admin.com"
+      fill_in "session[password]", with: "password"
       click_button("Log in")
       expect(page).to have_content("Admin Dashboard")
     end

--- a/spec/integration/admin_login_spec.rb
+++ b/spec/integration/admin_login_spec.rb
@@ -1,0 +1,24 @@
+require "spec_helper"
+
+describe "admin authorization", type: :feature do
+  include Capybara::DSL
+
+  describe "admin login" do
+    it "allows a user to log in as an admin and go to the dashboard" do
+      create(:admin)
+
+      visit root_url
+      click_link("Login")
+      fill_in "session[email]", :with => "admin@admin.com"
+      fill_in "session[password]", :with => "password"
+      click_button("Log in")
+      expect(page).to have_content("Admin Dashboard")
+    end
+
+  end
+
+
+
+
+end
+

--- a/spec/integration/admin_login_spec.rb
+++ b/spec/integration/admin_login_spec.rb
@@ -17,8 +17,4 @@ describe "admin authorization", type: :feature do
 
   end
 
-
-
-
 end
-

--- a/spec/integration/admin_login_spec.rb
+++ b/spec/integration/admin_login_spec.rb
@@ -9,8 +9,8 @@ describe "admin authorization", type: :feature do
 
       visit root_url
       click_link("Login")
-      fill_in "session[email]", :with => "admin@admin.com"
-      fill_in "session[password]", :with => "password"
+      fill_in "session[email]", { with: "admin@admin.com" }
+      fill_in "session[password]", { with: "password" }
       click_button("Log in")
       expect(page).to have_content("Admin Dashboard")
     end

--- a/spec/integration/admin_view_spec.rb
+++ b/spec/integration/admin_view_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe "the admin view", type: :feature do
+describe "the admin view", type: feature do
   include Capybara::DSL
 
   before(:each) do
@@ -10,7 +10,6 @@ describe "the admin view", type: :feature do
   end
 
   describe "home page" do
-
     xit "shows an admin link on the homepage when admin logged in" do
       visit root_url
       within first(".navbar-nav") do

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Admin, type: "model" do
 
   it "only is valid with a unique email" do
     create(:admin)
-    admin = build(:admin, email: "nope@nope.com")
+    admin = build(:admin, email: "admin@admin.com")
 
     expect(admin).not_to be_valid
   end


### PR DESCRIPTION
Created a test to verify that when an admin user logs in, they were brought to the admin dashboard. This necessitated modifications to the Sessions Controller, and application controller.

Sessions controller now checks to see if user is an admin. If not, it will attempt authentication as a regular user.

Application controller handles @current_user differently now. If a user is an admin, the sessions hash now has a key :admin that is true. If it is a regular user, the value is nil. This will allow the application controller to successfully create a session for said user.

![image](https://cloud.githubusercontent.com/assets/3011748/5889643/69f17a38-a3ef-11e4-9bdf-4dfc79f75e32.png)
