### PR TITLE
fixed paperclip from creating ALL of the files closes #138

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,42 +1,24 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb.
-
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
+  Paperclip::Attachment.default_options[:path] =
+    "#{Rails.root}/spec/test_files/:class/:id_partition/:style.:extension"
   config.cache_classes = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
-  # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'
 
-  # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-  # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 
-  # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,4 +17,7 @@ RSpec.configure do |config|
   config.color = true
 
   config.tty = true
+  config.after(:suite) do
+    FileUtils.rm_rf(Dir["#{Rails.root}/spec/test_files/"])
+  end
 end


### PR DESCRIPTION
Added some paperclip stuff from https://github.com/thoughtbot/paperclip

In our test environment with integration testing, paperclip will create files in a temp directory, and when testing is complete, it will delete them.
