### PR TITLE
Add item view spec; closes #95

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ActiveRecord::Base
   has_secure_password
+  has_many :orders
+  has_many :order_items, through: :orders
   validates :full_name, presence: true
   validates :email, uniqueness: true
   validates :display_name, length: { in: 2..32 }, allow_nil: true

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,5 +8,7 @@
   <br />
   <span class="item-desc"><%= @item.description %></span></br>
   <%= @item.dollar_amount %></br>
-  <%= button_to "Add to cart", cart_path(item_id: @item.id) %>
+  <% if @item.active? %>
+    <%= button_to "Add to cart", cart_path(item_id: @item.id) %>
+  <% end %>
 </div>

--- a/spec/integration/item_view_spec.rb
+++ b/spec/integration/item_view_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe "the user item view" do
+  include Capybara::DSL
+  attr_reader :image
+
+  before(:each) do
+    user = create(:user)
+    allow_any_instance_of(ApplicationController). to receive(:current_user).
+    and_return(user)
+    @image = create(:image)
+  end
+
+  it "shows an add to cart button for active items" do
+    item = create(:item, image_id: @image.id)
+
+    visit item_path(item.id)
+
+    expect(page).to have_button("Add to cart")
+  end
+
+  it "does not show an add to cart button for retired items" do
+    item = create(:item, active: false, image_id: @image.id)
+
+    visit item_path(item.id)
+
+    expect(page).to_not have_button("Add to cart")
+  end
+end

--- a/spec/integration/user_views_spec.rb
+++ b/spec/integration/user_views_spec.rb
@@ -137,20 +137,6 @@ describe "the user" do
       expect(page).to have_content("Order Total: $#{5 * @item.unit_price / 100}")
     end
 
-    it "shows the order time and status " do
-      user = create(:user)
-      allow_any_instance_of(ApplicationController). to receive(:current_user).
-      and_return(user)
-      create_one_item_with_one_category
-      add_item_five_times_to_cart
-
-      visit cart_path
-      click_link_or_button("Checkout")
-
-      expect(page).to have_content("Order placed at: ")
-      expect(page).to have_content("Current status: ordered")
-    end
-
     it "shows the order time and status" do
       user = create(:user)
       allow_any_instance_of(ApplicationController). to receive(:current_user).
@@ -171,7 +157,6 @@ describe "the user" do
       and_return(user)
       create_one_item_with_one_category
       add_item_five_times_to_cart
-
       visit cart_path
       click_link_or_button("Checkout")
 
@@ -180,6 +165,7 @@ describe "the user" do
       end
 
       expect(current_path).to eq(item_path(@item.id))
+      expect(page).to have_link("#{@item.title}")
     end
   end
 
@@ -194,6 +180,29 @@ describe "the user" do
 
       expect(current_path).to eq(orders_path)
       expect(page).to have_content("Your Past Orders")
+    end
+
+    it "shows the details for a past order" do
+      user = create(:user)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+      and_return(user)
+      order = Order.create(user_id: user.id,
+                           status:  "ordered",
+                           total_price: 14678)
+      item = create(:item)
+      order_item = OrderItem.create(order_id:        order.id,
+                                    item_id:         item.id,
+                                    quantity:        5,
+                                    line_item_price: 5 * item.unit_price)
+      order.order_items << order_item
+      visit root_path
+
+      click_link("Past Orders")
+
+      within("tbody") do
+        expect(page).to have_content("#{order.total_dollar_amount}")
+        expect(page).to have_content("#{order.created_at}")
+      end
     end
   end
 


### PR DESCRIPTION
This pull request ensures that only active items have an Add to Cart button visible on their show page.

An new integration test (item_view_spec.rb) was added to test this.
