### PR TITLE
added admin ability to add categories closes #158

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -7,6 +7,15 @@ class Admin::CategoriesController < ApplicationController
     @category = Category.find(params[:id])
   end
 
+  def new
+    @category = Category.new
+  end
+
+  def create
+    @category = Category.create(category_params)
+    redirect_to categories_path
+  end
+
   def update
     @category = Category.find(params[:id])
     @category.update(category_params)

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,4 +1,6 @@
 <% @categories.each do |category| %>
   <p><h4> <%= category.id %> <%= category.name %></h4></p>
   <%= link_to "Edit Category", edit_category_path(category.id) %>
+
 <% end %>
+<p><%= link_to "Create Category", new_category_path %></p>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -1,6 +1,5 @@
 <% @categories.each do |category| %>
   <p><h4> <%= category.id %> <%= category.name %></h4></p>
   <%= link_to "Edit Category", edit_category_path(category.id) %>
-
 <% end %>
 <p><%= link_to "Create Category", new_category_path %></p>

--- a/app/views/admin/categories/new.html.erb
+++ b/app/views/admin/categories/new.html.erb
@@ -1,0 +1,15 @@
+<h2 class="admin-title">Create New Category</h2>
+<div class="row">
+  <div class="col-lg-3">
+    <%= render 'admin/shared/admin_menu' %>
+  </div>
+  <div class="col-lg-9">
+    <div class="col-md-8 col-md-offset-2 well">
+      <%= form_for @category do |f| %>
+        <%= f.label :name %></br>
+        <%= f.text_field :name %></br>
+        <p><%= f.submit %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/shared/_admin_menu.html.erb
+++ b/app/views/admin/shared/_admin_menu.html.erb
@@ -4,6 +4,6 @@
     <hr />
     <li><%= link_to "Dashboard", admin_path %></li>
     <li><%= link_to "Manage Items", items_path %></li>
-    <li><%= link_to "Manage Categories", "#" %></li>
+    <li><%= link_to "Manage Categories", categories_path %></li>
   </ul>
 </div>

--- a/spec/integration/admin_add_category_spec.rb
+++ b/spec/integration/admin_add_category_spec.rb
@@ -1,0 +1,60 @@
+require "spec_helper"
+
+describe "admin adding cateogries", type: :feature do
+
+  describe "the category list page" do
+
+    it "has a category in there" do
+      user = create(:admin)
+      create(:category)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+                                                  and_return(user)
+
+      visit categories_path
+
+      expect(page).to have_link("Create Category")
+    end
+  end
+
+  describe "the category add page" do
+
+    it "has a category add page" do
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+        and_return(user)
+
+      visit new_category_path
+
+      expect(page).to have_content("Create New Category")
+    end
+
+    it "can add a category" do
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(user)
+
+      visit new_category_path
+      fill_in "category[name]", with: "NEW CATEGORY"
+      click_link_or_button ("Create Category")
+
+      expect(page).to have_content("NEW CATEGORY")
+    end
+
+    it "redirects to categories page when done" do
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController).
+        to receive(:current_user).
+        and_return(user)
+
+      visit new_category_path
+      fill_in "category[name]", with: "NEW CATEGORY"
+      click_link_or_button ("Create Category")
+
+      expect(current_path).to eq(categories_path)
+    end
+
+  end
+
+end
+

--- a/spec/integration/admin_add_category_spec.rb
+++ b/spec/integration/admin_add_category_spec.rb
@@ -53,8 +53,5 @@ describe "admin adding cateogries", type: :feature do
 
       expect(current_path).to eq(categories_path)
     end
-
   end
-
 end
-

--- a/spec/integration/edit_category_spec.rb
+++ b/spec/integration/edit_category_spec.rb
@@ -21,7 +21,6 @@ describe "editing categories woo", type: :feature do
       allow_any_instance_of(ApplicationController). to receive(:current_user).
                                                   and_return(user)
 
-
       visit categories_path
 
       expect(page).to have_link("Edit Category")
@@ -32,7 +31,6 @@ describe "editing categories woo", type: :feature do
       user = create(:admin)
       allow_any_instance_of(ApplicationController). to receive(:current_user).
                                                   and_return(user)
-
 
       visit categories_path
       first(:link, "Edit Category").click
@@ -45,7 +43,6 @@ describe "editing categories woo", type: :feature do
       user = create(:admin)
       allow_any_instance_of(ApplicationController). to receive(:current_user).
                                                   and_return(user)
-
 
       visit categories_path
       first(:link, "Edit Category").click

--- a/spec/integration/edit_category_spec.rb
+++ b/spec/integration/edit_category_spec.rb
@@ -6,6 +6,10 @@ describe "editing categories woo", type: :feature do
 
     it "starts with category in index" do
       create(:category)
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+                                                  and_return(user)
+
 
       visit categories_path
 
@@ -14,6 +18,10 @@ describe "editing categories woo", type: :feature do
 
     it "has an editing link" do
       create(:category)
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+                                                  and_return(user)
+
 
       visit categories_path
 
@@ -22,6 +30,10 @@ describe "editing categories woo", type: :feature do
 
     it "has an editing link that works" do
       create(:category)
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+                                                  and_return(user)
+
 
       visit categories_path
       first(:link, "Edit Category").click
@@ -31,6 +43,10 @@ describe "editing categories woo", type: :feature do
 
     it "edits categories" do
       create(:category)
+      user = create(:admin)
+      allow_any_instance_of(ApplicationController). to receive(:current_user).
+                                                  and_return(user)
+
 
       visit categories_path
       first(:link, "Edit Category").click

--- a/spec/integration/edit_category_spec.rb
+++ b/spec/integration/edit_category_spec.rb
@@ -10,7 +10,6 @@ describe "editing categories woo", type: :feature do
       allow_any_instance_of(ApplicationController). to receive(:current_user).
                                                   and_return(user)
 
-
       visit categories_path
 
       expect(page).to have_content("Drinks")


### PR DESCRIPTION
Added the ability for an admin to add categories.

Because I made it for an admin to add them, it broke the edit category tests, which I modified to let only admin edit categories.

I also changed the admin menu bar link from a placeholder to the categories index.
