### PR TITLE
Admin order count by status; closes #105

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,6 @@ require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
 
-# namespace :test do
-#   namespace :spec do
-#     task prepare: :environment do
-#       Rake::Task["db:seed"].invoke
-#     end
-#   end
-# end
 namespace :db do
   desc "Rebuild database"
   task :rebuild, [] => :environment do

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,6 +7,13 @@ class Order < ActiveRecord::Base
 
   validates :user_id, presence: true
 
+  scope :ordered,
+    -> { where("status = ?", "ordered") }
+  scope :paid,
+    -> { where("status = ?", "paid") }
+  scope :completed,
+    -> { where("status = ?", "completed") }
+
   def formatted_created_at
     formatted_time(created_at)
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,12 +7,9 @@ class Order < ActiveRecord::Base
 
   validates :user_id, presence: true
 
-  scope :ordered,
-    -> { where("status = ?", "ordered") }
-  scope :paid,
-    -> { where("status = ?", "paid") }
-  scope :completed,
-    -> { where("status = ?", "completed") }
+  scope :ordered, -> { where("status = ?", "ordered") }
+  scope :paid, -> { where("status = ?", "paid") }
+  scope :completed, -> { where("status = ?", "completed") }
 
   def formatted_created_at
     formatted_time(created_at)

--- a/app/views/admin/_daily_summary.html.erb
+++ b/app/views/admin/_daily_summary.html.erb
@@ -1,6 +1,6 @@
 <table>
   <tr colspan="4">
-    <th>Daily Summary</th>
+    <th>Summary by Status</th>
   </tr>
   <tr>
     <td>Ordered</td>
@@ -9,9 +9,9 @@
     <td>Total</td>
   </tr>
   <tr>
-    <td>4</td>
-    <td>5</td>
-    <td>6</td>
-    <td>27</td>
+    <td><%= @orders.ordered.count %></td>
+    <td><%= @orders.paid.count %></td>
+    <td><%= @orders.completed.count %></td>
+    <td><%= @orders.count %></td>
   </tr>
 </table>

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -4,7 +4,7 @@
     <%= render 'admin/shared/admin_menu' %>
   </div>
   <div class="col-lg-9 well">
-    <div class="dash-section clearfix">
+    <div class="dash-section clearfix summary">
       <h3 class="admin-panel-title">Order Summary</h3>
       <div class="col-md-6 summary-stat-box">
         <%= render 'daily_summary' %>

--- a/spec/integration/admin_orders_spec.rb
+++ b/spec/integration/admin_orders_spec.rb
@@ -77,7 +77,7 @@ describe "the order dashboard", type: :feature do
   end
 
   def mock_seven_paid_orders
-    7.times do |i|
+    7.times do
       Order.create(user_id: user.id,
                    status:  "paid",
                    total_price: 1469)

--- a/spec/integration/admin_orders_spec.rb
+++ b/spec/integration/admin_orders_spec.rb
@@ -34,17 +34,33 @@ describe "the order dashboard", type: :feature do
 
     visit admin_path
     click_button("Ordered")
+
     within("table.table.table-striped.orders-table") do
       expect(page).to have_link("#{order.id}")
       expect(page).to_not have_link("#{completed_order.id}")
     end
   end
 
+  it "shows total count by status" do
+    mock_admin
+    mock_order
+    mock_completed_order
+    mock_seven_paid_orders
+
+    visit admin_path
+    click_button("Ordered")
+
+    within("div.dash-section.clearfix.summary") do
+      expect(page).to have_content("1")
+      expect(page).to have_content("7")
+      expect(page).to have_content("9")
+    end
+  end
+
   def mock_admin
     admin = create(:admin)
     allow_any_instance_of(ApplicationController).
-    to receive(:current_user).
-    and_return(admin)
+    to receive(:current_user).and_return(admin)
   end
 
   def mock_order
@@ -52,17 +68,19 @@ describe "the order dashboard", type: :feature do
     @order = Order.create(user_id: user.id,
                           status:  "ordered",
                           total_price: 14678)
-    item = create(:item)
-    order_item = OrderItem.create(order_id:        order.id,
-                                  item_id:         item.id,
-                                  quantity:        5,
-                                  line_item_price: 5 * item.unit_price)
-    order.order_items << order_item
   end
 
   def mock_completed_order
     @completed_order = Order.create(user_id: user.id,
                                     status:  "completed",
                                     total_price: 146789)
+  end
+
+  def mock_seven_paid_orders
+    7.times do |i|
+      Order.create(user_id: user.id,
+                   status:  "paid",
+                   total_price: 1469)
+    end
   end
 end


### PR DESCRIPTION
This addresses the user story, "As an admin, when I visit the admin dashboard, I can see a total count of orders by status".
